### PR TITLE
Fix: add requests as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 youtube-dl 
 youtube-search-python
 pyfiglet
+requests


### PR DESCRIPTION
`requests` is imported but needed to install manually. Adding it in `requirements.txt` will fix this.
